### PR TITLE
7/fixed layout

### DIFF
--- a/assets/css/subway.css
+++ b/assets/css/subway.css
@@ -1,3 +1,7 @@
+/* Base styles
+---------------------------------------------------------------------*/
+html { overflow: hidden; }
+
 /* Shared classes
 ---------------------------------------------------------------------*/
 
@@ -295,8 +299,10 @@
 }
 
 #user-list {
+  position: absolute;
+  top: 34px;
+  bottom: 0;
   overflow-y: auto;
-  height: 95%;
 }
 
 .userlist_user {

--- a/views/templates.jade
+++ b/views/templates.jade
@@ -59,7 +59,7 @@ script(id="chat", type="text/html")
     #user-bar.bar
       .titlebar
         span(class='window_title') User List
-    #user-list
+    #user-list.bar
 
 script(id="channel", type="text/html")
   span(class="channel-name") {{name}}


### PR DESCRIPTION
Check it out -- no funky stretching of input-bar & top bars.

One issue (present before this change) is that topics just aren't fitting in the `#chat-bar`. I think that should be reworked to either a) occupy a new box below the `#chat-bar`, or b) cut off after a short # of characters, with the full title accessible by clicking or hover. Twitter Bootstrap popovers might be good for this.
