### PR TITLE
missing step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ Installation
     $ git clone https://github.com/thedjpetersen/subway.git
     $ cd subway
 
-2. Launch the web server
+2. Install the dependencies using npm:
+    
+    $ npm install
+
+3. Launch the web server
 
     $ node subway
 
-3. Point your browser at `http://localhost:3000/`
+4. Point your browser at `http://localhost:3000/`
 
 
 Development


### PR DESCRIPTION
Added a step 2 in README.md to run npm install. A minor thing, but node/npm newbies like me could easily get tripped up by it.
