### PR TITLE
optionally connect to irc with ssl

### DIFF
--- a/assets/js/views/overview.js
+++ b/assets/js/views/overview.js
@@ -47,6 +47,8 @@ var OverviewView = Backbone.View.extend({
     $('.error').removeClass('error');
     var server = $('#connect-server').val();
     var nick = $('#connect-nick').val();
+    var ssl = $('#connect-ssl').val();
+    var port = $('#connect-port').val();
     if (!server) {
       $('#connect-server').closest('.clearfix').addClass('error');
       $('#connect-server').addClass('error');
@@ -55,13 +57,21 @@ var OverviewView = Backbone.View.extend({
       $('#connect-nick').closest('.clearfix').addClass('error');
       $('#connect-nick').addClass('error');
     }
+    if (!ssl) {
+      ssl = false;
+    }
+    if (!port) {
+      port = ssl ? 6697 : 6667;
+    }
     if (nick && server) {
       $('form').append(ich.load_image());
       $('#connect-button').addClass('disabled');
 
       var connectInfo = {
         nick: nick,
-        server: server
+        server: server,
+        ssl: ssl,
+        port: port
       };
       irc.me = new User(connectInfo);
       irc.me.on('change:nick', irc.appView.renderUserBox);

--- a/lib/irchandler.js
+++ b/lib/irchandler.js
@@ -123,6 +123,9 @@ var irchandler = exports.irchandler = function(socket) {
     }
     if(client === undefined) {
       client = new irc.Client(data.server, data.nick, {
+        port: data.port,
+        secure: data.ssl,
+        selfSigned: true,
         debug: true,
         logged_in: false,
         showErrors: true,

--- a/views/templates.jade
+++ b/views/templates.jade
@@ -35,13 +35,21 @@ script(id="overview_connection", type="text/html")
     a.overview_button#home Home
   form.form-horizontal
     .control-group
+      label(for="connect-nick") Nick
+      .controls
+        input#connect-nick(type="text")
+    .control-group
       label(for="connect-server") Server
       .controls
         input#connect-server(type="text")
     .control-group
-      label(for="connect-nick") Nick
+      label(for="connect-port") Port
       .controls
-        input#connect-nick(type="text")
+        input#connect-port(type="text")
+    .control-group
+      label(for="connect-ssl") SSL
+      .controls
+        input#connect-ssl(type="checkbox")
     a(id="connect-button", class="btn btn-primary", type="button") Connect
 
 script(id="overview_settings", type="text/html")


### PR DESCRIPTION
Adds ssl checkbox and port text box for specifying connecting via ssl and on a specific port.

Defaults to ssl off, port defaults to 6667. If ssl is specified and port is not it defaults to port 6697.

For it to work with oftc martynsmith/node-irc#79 needs to be merged.
