### PR TITLE
make channel list scrollable, fix issue #72

### DIFF
--- a/assets/css/subway.css
+++ b/assets/css/subway.css
@@ -138,6 +138,14 @@ html { overflow: hidden; }
   margin-right: 5px;
 }
 
+#channels {
+  position: absolute;
+  top: 290px;
+  bottom: 0;
+  overflow: auto;
+  width: 100%;
+}
+
 #channels > .channel {
   padding: 5% 5% 5% 20%;
   color: #333333;


### PR DESCRIPTION
The top distance value is a bit tricky because of the elements above, but this looks perfect in Chrome and good in Firefox.
