### PR TITLE
Show the logged-in username instead of the server

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -54,6 +54,7 @@ $(function() {
   });
 
   irc.socket.on('login_success', function(data) {
+    irc.username = data.username;
     if(data.exists){
       irc.socket.emit('connect', {});
     } else {
@@ -72,7 +73,7 @@ $(function() {
   });
 
   irc.socket.on('restore_connection', function(data) {
-    irc.me = new User({nick: data.nick, server: data.server});
+    irc.me = new User({nick: data.nick, server: (irc.username) ? irc.username : data.server, username: irc.username});
     irc.connected = true;
     irc.appView.render();
     irc.appView.renderUserBox();


### PR DESCRIPTION
If we have a logged in user, show the username they logged in with,
instead of the server on the user-box on the sidebar.

There's little space left there, so adding the username separately
isn't a particularly good choice.

This fixes #149.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
