### PR TITLE
Support various encodings

### DIFF
--- a/assets/js/views/overview.js
+++ b/assets/js/views/overview.js
@@ -56,7 +56,8 @@ var OverviewView = Backbone.View.extend({
     secure = $('#connect-secure').is(':checked'),
     selfSigned = $('#connect-selfSigned').is(':checked'),
     rejoin = $('#connect-rejoin').is(':checked'),
-    password = $('#connect-password').val();
+    password = $('#connect-password').val(),
+    encoding = $('#connect-encoding').val();
     
     if (!server) {
       $('#connect-server').closest('.control-group').addClass('error');
@@ -79,7 +80,8 @@ var OverviewView = Backbone.View.extend({
         rejoin: rejoin,
         away: away,
         realName: realName,
-        password: password
+        password: password,
+        encoding: encoding
       };
 
       irc.me = new User(connectInfo);

--- a/lib/irclink.js
+++ b/lib/irclink.js
@@ -8,7 +8,7 @@ var Connection = mongoose.model('Connection');
 var Message = mongoose.model('Message');
 
 // Constructor
-var IRCLink = function(hostname, port, ssl, selfSigned, nick, realName, password, rejoin, away, channels) {
+var IRCLink = function(hostname, port, ssl, selfSigned, nick, realName, password, rejoin, away, encoding, channels) {
   this.sockets = new Array();
   this.server = hostname;
   
@@ -39,7 +39,8 @@ var IRCLink = function(hostname, port, ssl, selfSigned, nick, realName, password
     certExpired: false,
     floodProtection: true,
     floodProtectionDelay: 1000,
-    stripColors: true
+    stripColors: true,
+    encoding: encoding
   });
   
   // Events to signal TO the front-end

--- a/lib/models.js
+++ b/lib/models.js
@@ -20,7 +20,8 @@ module.exports = function() {
     selfSigned: Boolean,
     channels: [String],
     nick: String,
-    password: String
+    password: String,
+    encoding: String
   });
   
   var Messages = new Schema({

--- a/lib/restore.js
+++ b/lib/restore.js
@@ -8,7 +8,7 @@ module.exports = function (connections) {
   // restore connections
   Connection.find({},function(err, docs){
     docs.forEach(function(doc){
-      var connection = new IRCLink(doc.hostname, doc.port, doc.ssl, doc.selfSigned, doc.nick, doc.realName, doc.password, doc.rejoin, doc.away, doc.channels);
+      var connection = new IRCLink(doc.hostname, doc.port, doc.ssl, doc.selfSigned, doc.nick, doc.realName, doc.password, doc.rejoin, doc.away, doc.encoding, doc.channels);
       connection.associateUser(doc.user);
       connections[doc.user] = connection;
       // set ourselves as away

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -56,7 +56,7 @@ module.exports = function(socket, connections) {
       connection = connections[current_user.username];
     }
     if(connection === undefined) {
-      connection = new IRCLink(data.server, data.port, data.secure, data.selfSigned, data.nick, data.realName, data.password, data.rejoin, data.away);
+      connection = new IRCLink(data.server, data.port, data.secure, data.selfSigned, data.nick, data.realName, data.password, data.rejoin, data.away, data.encoding);
       
       // save this connection
       if(current_user){
@@ -73,7 +73,8 @@ module.exports = function(socket, connections) {
                                     selfSigned: data.selfSigned,
                                     channels: data.channels,
                                     nick: data.nick,
-                                    password: data.password });
+                                    password: data.password,
+                                    encoding: data.encoding});
                                     
         conn.save();
         connections[current_user.username] = connection;

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "express": "2.5.x",
     "jade": "0.26.x",
     "connect-assets": "2.2.x",
-    "irc": "git://github.com/martynsmith/node-irc.git",
+    "irc": "git://github.com/noraesae/node-irc.git",
     "socket.io": "0.9.x",
     "mongoose": "2.7.x",
-    "bcrypt": "0.7.x"
+    "bcrypt": "0.7.x",
+    "iconv": "1.2.x"
   },
   "noAnalyze": true,
   "subdomain": "subway",

--- a/views/templates.jade
+++ b/views/templates.jade
@@ -62,6 +62,31 @@ script(id="overview_connection", type="text/html")
       .control-group
         label(for="connect-rejoin") Bouncer Mode
         input#connect-rejoin(type="checkbox")
+      .control-group
+        label(for="connect-encoding") Encoding
+        select#connect-encoding
+          option(value="", selected="selected") UTF-8
+          option(disabled="disabled") --------------
+          option(value="ISO-8859-1") ISO-8859-1
+          option(value="ISO-8859-15") ISO-8859-15
+          option(value="ISO-8859-2") ISO-8859-2
+          option(value="ISO-8859-7") ISO-8859-7 (Greek)
+          option(value="ISO-8859-8") ISO-8859-8 (Hebrew)
+          option(value="ISO-8859-9") ISO-8859-9 (Turkish)
+          option(value="ISO-8859-11") ISO-8859-11 (Thai)
+          option(disabled="disabled") --------------
+          option(value="ISO-2022-JP") ISO-2022-JP (Japanese)
+          option(value="CP949") CP949 (Korean)
+          option(value="EUC-KR") EUC-KR (Korean)
+          option(value="GBK") GBK (Chinese)
+          option(value="GB18030") GB18030 (Chinese)
+          option(value="BIG5") BIG5 (Chinese)
+          option(disabled="disabled") --------------
+          option(value="KOI8-U") KOI8-U (Ukrainian)
+          option(value="KOI8-R") KOI8-R (Cyrillic)
+          option(value="CP1251") CP1251 (Cyrillic)
+          option(value="CP1256") CP1256 (Arabic)
+          option(value="CP1257") CP1257 (baltic)
     a(id="connect-button", class="btn btn-primary spacing-right", type="button") Connect
     a(id="connect-more-options-button", class="btn", type="button") More Options
 


### PR DESCRIPTION
Support various encodings other than UTF8.

Originally, node-irc doesn't support encodings and there's a pull request of supporting encodings for node-irc but it's not been accepted for 5 months.

So I forked the node-irc repo to support encodings and I hope that until the pull request is accepted, please use my repo instead of martynsmith's for package.json. I'll continuously update the repo with latest version of martynsmith's.

I also added a select element in 'More Options' of server connect page and modify front-end javascript to handle it. The options in the select element are major irc encodings (used with limeChat).

And the other patch is adding new line at end of file. You can merge this or not.

Thanks!
