### PR TITLE
Fix that 'home' doesn't work after login or register

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -79,7 +79,7 @@ $(function() {
       irc.socket.emit('connect', {});
       window.irc.loggedIn = true;
     } else {
-      $('#overview').html(ich.overview_connection());
+      irc.appView.overview.render({currentTarget: {id: "connection"}});
     }
   });
 
@@ -90,7 +90,7 @@ $(function() {
   
 
   irc.socket.on('register_success', function(data) {
-    $('#overview').html(ich.overview_connection());
+    irc.appView.overview.render({currentTarget: {id: "connection"}});
   });
 
   irc.socket.on('restore_connection', function(data) {

--- a/assets/js/views/chat_application.js
+++ b/assets/js/views/chat_application.js
@@ -36,10 +36,12 @@ var ChatApplicationView = Backbone.View.extend({
     this.render();
   },
 
+  overview: null,
+
   render: function() {
     $('body').html($(this.el).html(ich.chat_application()));
     if (!irc.connected) {
-      var overview = new OverviewView;
+      this.overview = new OverviewView;
     } else {
       this.channelList = new ChannelListView;
     }


### PR DESCRIPTION
There was the bug that the 'home' button doesn't work in connection view after login or register.

The problem is, 

$('#overview').html(ich.overview_connection());

is not enough to render a connection view because just with that line, the handlers for overview_button would not be attached.

With the OverviewView class' render function, it works right.
