### PR TITLE
make 'keeping connection alive' optional

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -75,9 +75,9 @@ $(function() {
   });
 
   irc.socket.on('login_success', function(data) {
+    window.irc.loggedIn = true;
     if(data.exists){
       irc.socket.emit('connect', {});
-      window.irc.loggedIn = true;
     } else {
       irc.appView.overview.render({currentTarget: {id: "connection"}});
     }
@@ -90,6 +90,7 @@ $(function() {
   
 
   irc.socket.on('register_success', function(data) {
+    window.irc.loggedIn = true;
     irc.appView.overview.render({currentTarget: {id: "connection"}});
   });
 

--- a/assets/js/views/overview.js
+++ b/assets/js/views/overview.js
@@ -22,7 +22,7 @@ var OverviewView = Backbone.View.extend({
       $('#overview').html(ich.overview_home());
     } else {
       var func = ich['overview_' + event.currentTarget.id];
-      $('#overview').html(func());
+      $('#overview').html(func({'loggedIn': irc.loggedIn}));
     }
 
     $('.overview_button').bind('click', $.proxy(this.render, this));
@@ -57,7 +57,8 @@ var OverviewView = Backbone.View.extend({
     selfSigned = $('#connect-selfSigned').is(':checked'),
     rejoin = $('#connect-rejoin').is(':checked'),
     password = $('#connect-password').val(),
-    encoding = $('#connect-encoding').val();
+    encoding = $('#connect-encoding').val(),
+    keepAlive = false;
     
     if (!server) {
       $('#connect-server').closest('.control-group').addClass('error');
@@ -65,6 +66,10 @@ var OverviewView = Backbone.View.extend({
     
     if (!nick) {
       $('#connect-nick').closest('.control-group').addClass('error');
+    }
+
+    if (irc.loggedIn && $('#connect-keep-alive').length) {
+      keepAlive = $('#connect-keep-alive').is(':checked');
     }
     
     if (nick && server) {
@@ -81,7 +86,8 @@ var OverviewView = Backbone.View.extend({
         away: away,
         realName: realName,
         password: password,
-        encoding: encoding
+        encoding: encoding,
+        keepAlive: keepAlive
       };
 
       irc.me = new User(connectInfo);

--- a/lib/irclink.js
+++ b/lib/irclink.js
@@ -8,7 +8,7 @@ var Connection = mongoose.model('Connection');
 var Message = mongoose.model('Message');
 
 // Constructor
-var IRCLink = function(hostname, port, ssl, selfSigned, nick, realName, password, rejoin, away, encoding, channels) {
+var IRCLink = function(hostname, port, ssl, selfSigned, nick, realName, password, rejoin, away, encoding, keepAlive, channels) {
   this.sockets = new Array();
   this.server = hostname;
   
@@ -42,6 +42,8 @@ var IRCLink = function(hostname, port, ssl, selfSigned, nick, realName, password
     stripColors: true,
     encoding: encoding
   });
+
+  this.keepAlive = keepAlive;
   
   // Events to signal TO the front-end
   this.events = {
@@ -136,6 +138,9 @@ IRCLink.prototype = {
         channel.unread_mentions = 0;
       }
     }
+  },
+  connect: function() {
+    this.client.connect();
   },
   disconnect: function() {
     this.client.disconnect();

--- a/lib/models.js
+++ b/lib/models.js
@@ -21,7 +21,8 @@ module.exports = function() {
     channels: [String],
     nick: String,
     password: String,
-    encoding: String
+    encoding: String,
+    keepAlive: Boolean
   });
   
   var Messages = new Schema({

--- a/lib/restore.js
+++ b/lib/restore.js
@@ -8,7 +8,7 @@ module.exports = function (connections) {
   // restore connections
   Connection.find({},function(err, docs){
     docs.forEach(function(doc){
-      var connection = new IRCLink(doc.hostname, doc.port, doc.ssl, doc.selfSigned, doc.nick, doc.realName, doc.password, doc.rejoin, doc.away, doc.encoding, doc.channels);
+      var connection = new IRCLink(doc.hostname, doc.port, doc.ssl, doc.selfSigned, doc.nick, doc.realName, doc.password, doc.rejoin, doc.away, doc.encoding, doc.keepAlive, doc.channels);
       connection.associateUser(doc.user);
       connections[doc.user] = connection;
       // set ourselves as away

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -57,7 +57,7 @@ module.exports = function(socket, connections) {
       connection = connections[current_user.username];
     }
     if(connection === undefined) {
-      connection = new IRCLink(data.server, data.port, data.secure, data.selfSigned, data.nick, data.realName, data.password, data.rejoin, data.away, data.encoding);
+      connection = new IRCLink(data.server, data.port, data.secure, data.selfSigned, data.nick, data.realName, data.password, data.rejoin, data.away, data.encoding, data.keepAlive);
       
       // save this connection
       if(current_user){
@@ -75,12 +75,16 @@ module.exports = function(socket, connections) {
                                     channels: data.channels,
                                     nick: data.nick,
                                     password: data.password,
-                                    encoding: data.encoding});
+                                    encoding: data.encoding,
+                                    keepAlive: data.keepAlive});
                                     
         conn.save();
         connections[current_user.username] = connection;
       }
     } else {
+      if(!connection.keepAlive) {
+        connection.connect();
+      }
       socket.emit('restore_connection', {nick: connection.client.nick,
         server: connection.client.opt.server, channels: connection.client.chans});
       connection.clearUnreads();
@@ -159,9 +163,15 @@ module.exports = function(socket, connections) {
         // not logged in, drop this session
         connection.disconnect();
       } else {
-        // keep the session alive, remove this socket, and clear unreads
-        connection.removeSocket(socket);
-        connection.clearUnreads();
+        if(connection.keepAlive) {
+          // keep the session alive, remove this socket, and clear unreads
+          connection.removeSocket(socket);
+          connection.clearUnreads();
+        }
+        else {
+          // disconnect the session
+          connection.disconnect();
+        }
       }
     });
 

--- a/views/templates.jade
+++ b/views/templates.jade
@@ -87,6 +87,11 @@ script(id="overview_connection", type="text/html")
           option(value="CP1251") CP1251 (Cyrillic)
           option(value="CP1256") CP1256 (Arabic)
           option(value="CP1257") CP1257 (baltic)
+    .control-group
+      {{#loggedIn}}
+      label.checkbox(for="connect-keep-alive", style="width:100%") Keep connection alive after browser closed
+        input#connect-keep-alive(type="checkbox")
+      {{/loggedIn}}
     a(id="connect-button", class="btn btn-primary spacing-right", type="button") Connect
     a(id="connect-more-options-button", class="btn", type="button") More Options
 


### PR DESCRIPTION
Make 'keeping connection alive after browser closed' feature optional and user-selectable.

I created the checkbox in server connection form.

If the user checked 'Keep connection alive..', the connection'll be kept alive after the browser is closed.

If not, the irc connection closed when the browser closed but it remember the server and channels, and when the user log in later, the user'll be connected with the setting the user used.

But for this patch, I can't assure if this changes are right(or best) way to implement this.
Please review the code, and let me know if there's something i can make better.
Also, you can test this patch here : http://subway.yuiazu.net/

Thanks.
