### PR TITLE
Chat input scrollback/history with additional fixes

### DIFF
--- a/assets/js/views/chat.js
+++ b/assets/js/views/chat.js
@@ -58,8 +58,7 @@ var ChatView = Backbone.View.extend({
         console.log(irc.chatWindows.getActive().get('name'));
         irc.socket.emit('say', {target: irc.chatWindows.getActive().get('name'), message:message});
       }
-      $('#chat-input').val('');
-      $('#chat-button').addClass('disabled');
+      $('#chat-input').val('').change();
     }
     $('#chat-button').click(sendMessage);
 


### PR DESCRIPTION
Added input scrollback via up and down arrow keys - Closes #121 
Escape key clears the message input box
Combining sendMessage code between pressing enter and clicking send
Let the onchange event of #chat-input enable/disable the send button
Only send a message if there is a message to send.
    Previously, you could click the send button with an empty
    message input, and a blank line would appear in the chat window.
