### PR TITLE
Workaround for Queries duplicating and sent replies disappearing.

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -184,12 +184,12 @@ $(function() {
   });
 
   irc.socket.on('pm', function(data) {
-    var chatWindow = irc.chatWindows.getByName(data.nick);
+    var chatWindow = irc.chatWindows.getByName(data.nick.toLowerCase());
     if (typeof chatWindow === 'undefined') {
-      irc.chatWindows.add({name: data.nick, type: 'pm'})
+      irc.chatWindows.add({name: data.nick.toLowerCase(), type: 'pm'})
         .trigger('forMe', 'newPm');
-      irc.socket.emit('getOldMessages',{channelName: data.nick, skip:0, amount: 50});
-      chatWindow = irc.chatWindows.getByName(data.nick);
+      irc.socket.emit('getOldMessages',{channelName: data.nick.toLowerCase(), skip:0, amount: 50});
+      chatWindow = irc.chatWindows.getByName(data.nick.toLowerCase());
     }
     chatWindow.stream.add({sender: data.nick, raw: data.text, type: 'pm'});
   });


### PR DESCRIPTION
As the user may be initiating a query with the incorrect case on a
username, it appears that the chat view was created as a lowercase
of the username. When a query reply was received, it had the proper
case, and would duplicate the window. Similarly, when sending a
reply to a query we received, we would look up a non-existant
stream due to an inconsistency of case.
This workaround forces all query views to have a lower-case name.
Proper resolution would be retrieving the correct username before
creating the view on both the sending and receiving ends.
