### PR TITLE
Fixed /topic handler

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -425,9 +425,10 @@ $(function() {
   });
 
   irc.commands.add('topic', function(args){
-    if (args[0].indexOf('#') == 0 || args[0].indexOf('&') == 0) {
+    // If args[0] starts with # or &, a topic name has been provided
+    if (args[0].indexOf('#') === 0 || args[0].indexOf('&') === 0) {
       irc.socket.emit('topic', {name: args.shift(), topic: args.join(' ')});
-    } else {
+    } else { // Otherwise, assume we're changing the current channel's topic
       irc.socket.emit('topic', {name: irc.chatWindows.getActive().get('name'),
         topic: args.join(' ')});
     }


### PR DESCRIPTION
Problem:
/topic This is a test # Would change the topic of channel "This"
    to "is", and ignore the rest
/topic #Channel This is a test # Would change the topic of channel
    "#Channel" to "This" and ignore the rest
Resolution:
If args[0] starts with # or &, a channel has been provided. Set the
    channel's name to args.shift(), and the topic to args.join(' ')
If args[0] does not start with # or &, set the active channel's
    topic to args.join(' ')
