### PR TITLE
Don't show unread-label on open (active) channel/chat

### DIFF
--- a/assets/js/views/channel_tab.js
+++ b/assets/js/views/channel_tab.js
@@ -34,6 +34,8 @@ var ChannelTabView = Backbone.View.extend({
     var unread = this.model.get('unread');
     var unreadMentions = this.model.get('unreadMentions');
 
+    if ($(this.el).hasClass('active')) return;
+
     // TODO: do something more sensible here than remove/readd elements
     // this.$el.children('.unread, .unread_mentions').remove();
 


### PR DESCRIPTION
Suggestion: Don't show the label for unread messages on incoming messages to an already open chat.  
I understand there is some logic for browser active/deactive state, but when always having the chat open on a monitor the label can become a bit annoying.
