### PR TITLE
set 'sync disconnect on unload' to false for socket.io client options.

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -12,7 +12,7 @@
 
 
 window.irc = {
-  socket: io.connect(null, {port: PORT}),
+  socket: io.connect(null, {port: PORT, 'sync disconnect on unload': false}),
   chatWindows: new WindowList(),
   connected: false,
   loggedIn: false


### PR DESCRIPTION
fixes issue #77
