### PR TITLE
Add support for channel keys.

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -403,7 +403,14 @@ $(function() {
   }());
 
   irc.commands.add('join', function(args){
-    irc.socket.emit('join', args[0]);
+    var connect = args[0];
+
+    // Support using channel keys and passwords.
+    if (args[1]) {
+      connect = connect + ' ' + args[1]
+    }
+
+    irc.socket.emit('join', connect);
   });
 
   irc.commands.add('part', function(args){


### PR DESCRIPTION
This adds support for joining password protected channels. The underlying library already supports this, so it was just a case of passing in the additional argument from the client.

/join #protected pa55word
