### PR TITLE
Add a dedicated field for joining channels.

### DIFF
--- a/assets/css/subway.css
+++ b/assets/css/subway.css
@@ -229,6 +229,21 @@ html { overflow: hidden; }
   margin-right: 0.3em;
 }
 
+#channels form {
+  width: 8em;
+  margin: 0 auto;
+}
+
+#channels label {
+  display: none;
+}
+
+#channels input {
+  width: 100%;
+  height: 12px;
+  font-size: 12px;
+}
+
 .slide {
   position: fixed;
   width: 0;

--- a/assets/js/views/channel_list.js
+++ b/assets/js/views/channel_list.js
@@ -12,6 +12,21 @@ var ChannelListView = Backbone.View.extend({
   initialize: function() {
     irc.chatWindows.bind('add', this.addChannel, this);
     $('.slide').css('display', 'inline-block');
+    $('#join-channel-name').bind({
+      keyup: function(event) {
+        if (event.keyCode == 13) {
+          event.preventDefault();
+          irc.socket.emit('join', $('#join-channel-name').val());
+          $('#join-channel-name').val('');
+        }
+      },
+      keydown: function(event) {
+        if (event.keyCode == 13) {
+          event.preventDefault();
+        }
+      }
+    });
+    $('#join-channel').css('display', 'block');
     this.channelTabs = []
   },
 
@@ -19,7 +34,7 @@ var ChannelListView = Backbone.View.extend({
     var $el = $(this.el);
     var view = new ChannelTabView({model: chatWindow});
     this.channelTabs.push(view);
-    $el.append(view.render().el);
+    $el.prepend(view.render().el);
 
     var name = chatWindow.get('name');
     if(name[0] === '#' || name === 'status'){

--- a/views/templates.jade
+++ b/views/templates.jade
@@ -9,6 +9,9 @@ script(id="chat_application", type="text/html")
     #channels
       #slide-prev.slide
       #slide-next.slide
+      form#join-channel.hide
+        label(for="join-channel-name") Join channel
+        input#join-channel-name(type="text", placeholder="Join #channel")
   .content
 
 script(id="load_image", type="text/html")


### PR DESCRIPTION
For many of our users, we're guiding them through their first experience with IRC. Most GUI clients have a dedicated field for joining a channel. This PR adds a join field below the channel list. It supports channel keys just by entering '#channel key123'.
![Subway 2013-03-29 18-21-15](https://f.cloud.github.com/assets/255023/319422/f964bfa6-98be-11e2-9313-345cb62e848b.jpg)
