### PR TITLE
Added handling for modes

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -190,6 +190,24 @@ $(function() {
     chatWindow.stream.add({sender: data.from, raw: ' ACTION ' + data.text, type: type});
   });
 
+  irc.socket.on('+mode', function(data) {
+    var chatWindow = irc.chatWindows.getByName(data.channel.toLowerCase());
+
+    var message = 
+      'sets mode +' + data.mode + ' on ' + (data.argument ? data.argument : data.channel);
+
+    chatWindow.stream.add({sender: data.by, raw: message, type: 'mode'});
+  });
+
+  irc.socket.on('-mode', function(data) {
+    var chatWindow = irc.chatWindows.getByName(data.channel.toLowerCase());
+
+    var message = 
+      'sets mode -' + data.mode + ' on ' + (data.argument ? data.argument : data.channel);
+
+    chatWindow.stream.add({sender: data.by, raw: message, type: 'mode'});
+  });
+
   irc.socket.on('pm', function(data) {
     var chatWindow = irc.chatWindows.getByName(data.nick.toLowerCase());
     if (typeof chatWindow === 'undefined') {

--- a/assets/js/models.js
+++ b/assets/js/models.js
@@ -12,7 +12,7 @@ var Message = Backbone.Model.extend({
     }
 
     //Temporary solution to make unread mentions work again
-    if (this.get('type') === 'message' && this.get('raw').search('\\b' + irc.me.get('nick') + '\\b') !== -1){
+    if ((this.get('type') === 'message' || this.get('type') == 'mode') && this.get('raw').search('\\b' + irc.me.get('nick') + '\\b') !== -1){
       this.set({mention: true});
     }
   },

--- a/assets/js/views/chat.js
+++ b/assets/js/views/chat.js
@@ -169,7 +169,7 @@ var ChatView = Backbone.View.extend({
       $(view.el).addClass('message-me');
     }
 
-    if(['join', 'part', 'topic', 'nick', 'quit'].indexOf(type) !== -1){
+    if(['join', 'part', 'topic', 'nick', 'quit', 'mode'].indexOf(type) !== -1){
       $(view.el).addClass('message_notification');
     }
 

--- a/assets/js/views/message.js
+++ b/assets/js/views/message.js
@@ -9,7 +9,7 @@ var MessageView = Backbone.View.extend({
     var nick = this.model.get('sender') || this.model.collection.channel.get('name');
     var html;
 
-    if (_.include(['join', 'part', 'nick', 'topic', 'quit'], this.model.get('type')))
+    if (_.include(['join', 'part', 'nick', 'topic', 'quit', 'mode'], this.model.get('type')))
       html = this.setText(this.model.get('type'));
     // This handles whether to output a message or an action
     else if (this.model.get('text') && this.model.get('text').substr(1, 6) === 'ACTION') {
@@ -63,6 +63,9 @@ var MessageView = Backbone.View.extend({
         break;
       case 'topic':
         html = '<span class="topic_img"></span><b>' + this.model.get('nick') + '</b> has changed the topic to <i>' + this.model.get('topic') + '</i>';
+        break;
+      case 'mode':
+        html = '<span class="topic_img"></span><b>' + this.model.get('sender') + '</b> ' + this.model.parse(this.model.get('raw'));
         break;
     }
     return html;


### PR DESCRIPTION
When a channel operator changes modes on the channel (such as voicing a
user or muting a channel), it will now display that in the chat. It will
also notify a user if the action was performed on them.
