### PR TITLE
Provide absolute path for loading models.js

### DIFF
--- a/lib/subway.js
+++ b/lib/subway.js
@@ -29,7 +29,7 @@ Subway.prototype.start = function () {
   // get the db rolling
   orm.connect({ protocol: "sqlite", pathname: config.sqlite_path }, function (err, db) {
     // load in models
-    db.load("lib/models", function (err) {
+    db.load(__dirname + "/models", function (err) {
       // create tables if needed
       db.sync(function (err) {
         // map ORM to app object


### PR DESCRIPTION
I've deployed subway on a debian wheezy server at work and I didn't have any problems. When I tried running it on OSX I would get the following error.

```
TypeError: Cannot call method 'find' of undefined
    at module.exports (/Users/asnodgrass/projects/subway/lib/restore.js:8:16)
    at Subway.start (/Users/asnodgrass/projects/subway/lib/subway.js:51:29)
    at ORM.<anonymous> (/Users/asnodgrass/projects/subway/node_modules/orm/lib/ORM.js:244:11)
    at ORM.sync (/Users/asnodgrass/projects/subway/node_modules/orm/lib/ORM.js:264:2)
    at Subway.start (/Users/asnodgrass/projects/subway/lib/subway.js:34:10)
    at ORM.load (/Users/asnodgrass/projects/subway/node_modules/orm/lib/ORM.js:237:10)
    at Subway.start (/Users/asnodgrass/projects/subway/lib/subway.js:32:8)
    at exports.connect (/Users/asnodgrass/projects/subway/node_modules/orm/lib/ORM.js:101:13)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```

I found that app.db.models was undefined and tracked it back to line 32 in lib/subway.js. I tried running it again with `if (err) throw err;` on line 33 to see if there were any errors.

```
Caught exception: Error: Cannot find module '/Users/asnodgrass/projects/subway/./models'
```

Not sure why this happened in OSX and not debian.
