### PR TITLE
Fixed Windows compatibility issue with loading models.

### DIFF
--- a/lib/subway.js
+++ b/lib/subway.js
@@ -7,7 +7,8 @@ var config = require('../config')
   , app = require('./webserver').app
   , server = require('./webserver').server
   , io = require('socket.io')
-  , orm = require("orm");
+  , orm = require("orm")
+  , path = require('path');
 
 
 // prevent crashes (node-irc is still unstable)
@@ -29,7 +30,7 @@ Subway.prototype.start = function () {
   // get the db rolling
   orm.connect({ protocol: "sqlite", pathname: config.sqlite_path }, function (err, db) {
     // load in models
-    db.load(__dirname + "/models", function (err) {
+    db.load(path.join(__dirname,  "/models"), function (err) {
       // create tables if needed
       db.sync(function (err) {
         // map ORM to app object


### PR DESCRIPTION
[fculpo pointed out](https://github.com/thedjpetersen/subway/pull/243#issuecomment-19504141) that the previous change broke loading models on Windows.  On Windows `__dirname + '/models'` returned `c:\someDirectory/models`. Using path.join uses the proper slash.
