### PR TITLE
Add notice messages to chatWindow when present

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -122,16 +122,17 @@ $(function() {
   });
 
   irc.socket.on('notice', function(data) {
-    var status = irc.chatWindows.getByName('status');
-    if(status === undefined){
+    var chatWindow = irc.chatWindows.getByName(data.to.toLowerCase());
+    chatWindow = chatWindow || irc.chatWindows.getByName('status');
+    if(chatWindow === undefined){
       irc.connected = true;
       irc.appView.render();
       irc.chatWindows.add({name: 'status', type: 'status'});
-      status = irc.chatWindows.getByName('status');
+      chatWindow = irc.chatWindows.getByName('status');
     }
     var sender = (data.nick !== undefined) ? data.nick : 'notice';
-    console.log(status);
-    status.stream.add({sender: sender, raw: data.text, type: 'notice'});
+    console.log(chatWindow);
+    chatWindow.stream.add({sender: sender, raw: data.text, type: 'notice'});
   });
 
   // Message of the Day


### PR DESCRIPTION
I could not see the notice messages I receive from github hooks.

So when the 'to' argument of the notice is a channel, it sends the message to that channel window instead of the status window.

I noticed by #32 that maybe the former behaviour is wanted, is there any reason for that? I can add an user setting to opt in for notices on channel room, in this case. This feature is a must for people who chat on software development related channels IMHO.

Fix #183 

BTW, thanks for all the work you've put on this, subway is awesome!
