### PR TITLE
Enable part commands in query window

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -433,7 +433,13 @@ $(function() {
       irc.socket.emit('part', args[0]);
       irc.appView.channelList.channelTabs[0].setActive();
     } else {
-      irc.socket.emit('part', irc.chatWindows.getActive().get('name'));
+      var chatWindow = irc.chatWindows.getActive();
+      if (chatWindow.get('type') === 'channel') {
+        irc.socket.emit('part', irc.chatWindows.getActive().get('name'));
+      }
+      else {
+        chatWindow.destroy();
+      }
       irc.appView.channelList.channelTabs[0].setActive();
     }
   });
@@ -491,4 +497,3 @@ $(function() {
   });
 
 });
-


### PR DESCRIPTION
If you run any command (/wc, /part, /close) in a query window, it sends
you to the status window with an error message.

This PR fixes that.
