### PR TITLE
Fix null reference to userList on query window

### DIFF
--- a/assets/js/views/chat.js
+++ b/assets/js/views/chat.js
@@ -88,10 +88,11 @@ var ChatView = Backbone.View.extend({
             }
             $(this).val('');
             $('#chat-button').addClass('disabled');
-          } else if (event.keyCode == 9) {
+          } else if (event.keyCode == 9 &&
+                     (channel = irc.chatWindows.getActive()) &&
+                     channel.userList) {
             var searchRe;
             var match = false;
-            var channel = irc.chatWindows.getActive();
             var sentence = $('#chat-input').val().trim().split(' ');
             var partialMatch = sentence.pop();
             var users = channel.userList.getUsers();


### PR DESCRIPTION
When the user types `tab` on a query window, subway tries to autocomplete with nicks provided by the userList.

But the userList is null, so it raises an error and the input box becomes unresponsive.

Fix #146 
