### PR TITLE
Hide horizontal scroll when user list overflows

### DIFF
--- a/assets/css/subway.css
+++ b/assets/css/subway.css
@@ -430,6 +430,7 @@ div.embed-toggle {
   position: absolute;
   top: 34px;
   bottom: 0;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
When user list is very long, the horizontal scroll bar appears.

Hide it.
