### PR TITLE
Set connected to false on disconnect

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -46,8 +46,9 @@ $(function() {
 
   // **TODO**: is there a better place for this to go?
   $(window).bind('beforeunload', function() {
-    if(!window.irc.connected || window.irc.loggedIn) { return null; }
-    return "If you leave, you'll be signed out of Subway.";
+    if(window.irc.connected && window.irc.loggedIn) { 
+      return "If you leave, you'll be signed out of Subway.";
+    }
   });
 
   // Registration (server joined)
@@ -76,6 +77,7 @@ $(function() {
   });
 
   irc.socket.on('disconnect', function() {
+    irc.connected = false;
     alert('You were disconnected from the server.');
     $('.container-fluid').css('opacity', '0.5');
   });


### PR DESCRIPTION
Make leave dialog only pop up when connected and logged in by returning a message, otherwise implicitly return undefined preventing the dialog box from popping open.
