### PR TITLE
Fix port mismatch when used behind a reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,6 @@ Contributors are welcome and greatly appreciated.
 Configuration
 -------------
 
-### Client Port
-
-You can set which port will be listened on the socket side with the
-`client_port` setting.
-
 ### Long Polling
 
 If for some reasons you can't establish websockets, (e.g. Heroku, browser
@@ -64,7 +59,6 @@ and it will use xhr-polling instead.
 Set the following environment vars to your app: 
 
 * USE\_POLLING=1
-* CLIENT\_PORT=80
 
 History
 -------

--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -11,7 +11,7 @@
 
 
 window.irc = {
-  socket: io.connect(null, {port: PORT}),
+  socket: io.connect(null, {port: document.location.port}),
   chatWindows: new WindowList(),
   connected: false,
   loggedIn: false

--- a/config.js
+++ b/config.js
@@ -23,13 +23,11 @@ module.exports = {
   },
 
   dev: {
-    port: process.env.PORT || 3000,
-    client_port: process.env.CLIENT_PORT || process.env.PORT || 3000
+    port: process.env.PORT || 3000
   },
 
   prod: {
-      port: process.env.PORT || 14858, // Nodester port
-    client_port: 80 // Websockets talk on port 80 on Nodester, regardless of listen port
+    port: process.env.PORT || 14858 // Nodester port
   },
 
   use_polling: process.env.USE_POLLING || false, // Use polling if websockets aren't supported

--- a/lib/webserver.js
+++ b/lib/webserver.js
@@ -17,7 +17,6 @@ app.configure(function() {
 // configure app based on given environment config
 function configureApp(app, envConfig) {
   app.set('port', envConfig.port);
-  app.set('client_port', envConfig.client_port);
 }
 
 app.configure('development', function() {
@@ -34,5 +33,5 @@ var port = app.get('port'); // get port for current environment
 server.listen(port);
 
 app.get('/', function(req, res) {
-  res.render('index.jade', {port: app.get('client_port'), env: process.env.NODE_ENV || null});
+  res.render('index.jade');
 });

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -8,9 +8,6 @@ html
     != css('subway-mobile')
     != css('irc-colors')
 
-    script
-      var ENV = '#{env}',
-          PORT = #{port};
     script(src='/socket.io/socket.io.js')
     != js('client')
     include templates


### PR DESCRIPTION
I tried using Subway on a Dokku instance and since it uses a reverse proxy to map port 80 to the port Subway uses, the generated script was using the internal port and causing subway to stop working. This patch solves the problem by simply using the same port where the document is loaded.
