### PR TITLE
Add support for server presets.

### DIFF
--- a/assets/js/views/chat_application.js
+++ b/assets/js/views/chat_application.js
@@ -37,8 +37,6 @@ var ChatApplicationView = Backbone.View.extend({
       clearTimeout(blurTimer);
       if(activeChat && activeChat.set) { activeChat.set('active', true); }
     });
-
-    this.render();
   },
 
   overview: null,

--- a/assets/js/views/overview.js
+++ b/assets/js/views/overview.js
@@ -19,10 +19,13 @@ var OverviewView = Backbone.View.extend({
 
     // Navigation to different overview panes
     if (event === undefined) {
-      $('#overview').html(ich.overview_home());
+      $('#overview').html(ich.overview_home({'presets': irc.presets}));
     } else {
       var func = ich['overview_' + event.currentTarget.id];
-      $('#overview').html(func({'loggedIn': irc.loggedIn}));
+      $('#overview').html(func({
+        'presets': irc.presets,
+        'loggedIn': irc.loggedIn
+      }));
     }
 
     $('.overview_button').bind('click', $.proxy(this.render, this));

--- a/config.js
+++ b/config.js
@@ -15,6 +15,23 @@ module.exports = {
   // server_whitelist: ["irc.freenode.net"],
   server_whitelist: false,
 
+  // If enabled, prevent creation of new accounts or editing settings.  These presets
+  // are used for all new user accounts.
+  presets: false,
+  /*
+  presets: {
+    server: "chat.freenode.net",
+    port: 6667,
+    secure: false,
+    selfSigned: false,
+    away: "AKF",
+    encoding: null,
+    stripColors: false,
+    keepAlive: true,
+    channels: ["#subway"],
+  },
+  */
+
   /* not implemented yet */
   user_access: {
       users_enabled: true,            // show and allow logins

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -32,6 +32,10 @@ module.exports = function(socket, app) {
     app.ircbridge.emit(connection, event, dict);
   }
 
+  socket.emit('initialized', {
+    presets: app.config.presets
+  });
+
   /* auth/setup commands */
 
   // user registration
@@ -87,7 +91,11 @@ module.exports = function(socket, app) {
                 socket.connID = connections[0].id;
                 socket.conn = connections[0];
               }
-              socket.emit('login_success', {username: data.username, exists: exists});
+              socket.emit('login_success', {
+                username: data.username,
+                nick: data.username,
+                exists: exists
+              });
             });
           } else {
             socket.emit('login_error', {message: 'Wrong password'});

--- a/views/templates.jade
+++ b/views/templates.jade
@@ -16,12 +16,14 @@ script(id="load_image", type="text/html")
 
 script(id="overview_home", type="text/html")
   ul
+    {{^presets}}
     li.overview_button#connection
       img(src="/assets/images/connection.svg")
       span New Connection
     li.overview_button#settings
       img(src="/assets/images/settings.svg")
       span Settings
+    {{/presets}}
     li.overview_button#login
       img(src="/assets/images/login.svg")
       span Login


### PR DESCRIPTION
To make it even easier for non-technical people to get started with IRC,
this change adds support for presets defined in config.js.  In such a
deployment, instead of requiring users to type in all the server
configuration parameters, subway automatically connects to the preset
server and joins a predefined set of channels.  After that, users may
join and leave channels as normal, but they cannot connect to other
servers.
