### PR TITLE
Gives user notification when a username is already registered.

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -341,6 +341,10 @@ $(function() {
   irc.socket.on('login_error', function(data) {
     irc.appView.showError(data.message);
   });
+  
+  irc.socket.on('register_error', function(data) {
+    irc.appView.showError(data.message);
+  });
 
   irc.socket.on('reset', function(data) {
     irc.chatWindows = new WindowList();

--- a/assets/js/views/chat_application.js
+++ b/assets/js/views/chat_application.js
@@ -56,12 +56,22 @@ var ChatApplicationView = Backbone.View.extend({
 
   // Net connection error
   showError: function(text) {
+    // Remove any old error messages
+    $(".alert").remove();
+
+    // Remove artifacts from submitting the form
     $('#loading_image').remove();
     $('.btn').removeClass('disabled');
+
+    // Add the error message
     $('#home_parent').after(ich.alert({
       type: 'alert-error',
       content: text
-    }).alert());
+    })
+    // Flash the alert box
+    .animate({ opacity: 0}, 200)
+    .animate({ opacity: 1}, 200)
+    .alert());
   },
 
   renderUserBox: function() {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -58,7 +58,7 @@ module.exports = function(socket, app) {
           });
         });
       } else {
-        socket.emit('register_error', {message: 'User exists.'});
+        socket.emit('register_error', {message: 'The username "' + data.username + '" is taken, please try another username.'});
       }
     });
   });


### PR DESCRIPTION
The server actually sent an event called 'register_error', but there were
nothing client-side that listened for it. This commit mitigates this.
It also clears up any old messages, so that they don't stack up, but rather
flashes when entering multiple bad passwords or already registered usernames.
