### PR TITLE
Adds button for joining a channel without writing /join

### DIFF
--- a/assets/css/subway.css
+++ b/assets/css/subway.css
@@ -162,7 +162,8 @@ html { overflow: hidden; }
   width: 100%;
 }
 
-#channels > .channel {
+#channels > .channel,
+#add-channel-button {
   padding: 5% 5% 5% 20%;
   color: #333333;
   border-bottom: 1px solid #CCCCCC;
@@ -241,6 +242,14 @@ html { overflow: hidden; }
 
 #logo > img {
   margin-top: 10px;
+}
+
+#add-channel-button #channelname {
+  width: 110px;
+  margin: 0;
+  font-size: 12px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 
 /* Here are the styles for the chat window */

--- a/assets/js/views/add_channel_button.js
+++ b/assets/js/views/add_channel_button.js
@@ -1,0 +1,42 @@
+var AddChannelView = Backbone.View.extend({
+  el: '#add-channel-button',
+
+  inputOn: false,
+
+  events: {
+    'click': 'enableButtonInput',
+    'keyup :input': 'processKey',
+    'blur :input': 'disableButtonInput',
+  },
+
+  initialize: function() {
+    this.render();
+  },
+
+  enableButtonInput: function() {
+    if (!this.inputOn) {
+      $(this.el).html(ich.add_new_channel_form());
+      this.inputOn = true;
+    }
+  },
+
+  disableButtonInput: function() {
+    if (this.inputOn) {
+      this.render();
+      this.inputOn = false;
+    }
+  },
+
+  processKey: function (event) {
+    if (event.which == 13) { // enter key
+      irc.socket.emit('join', event.target.value);
+    }
+    return false;
+  },
+
+  render: function(){
+    $(this.el).html(ich.add_new_channel());
+    return this;
+  }
+
+});

--- a/assets/js/views/channel_list.js
+++ b/assets/js/views/channel_list.js
@@ -6,13 +6,15 @@ var ChannelListView = Backbone.View.extend({
 
   events: {
     'click #slide-prev': 'slidePrev',
-    'click #slide-next': 'slideNext'
+    'click #slide-next': 'slideNext',
   },
 
   initialize: function() {
     irc.chatWindows.bind('add', this.addChannel, this);
     $('.slide').css('display', 'inline-block');
     this.channelTabs = []
+    var new_channel_btn = new AddChannelView;
+    $(this.el).after(new_channel_btn);
   },
 
   addChannel: function(chatWindow) {

--- a/views/templates.jade
+++ b/views/templates.jade
@@ -9,7 +9,15 @@ script(id="chat_application", type="text/html")
     #channels
       #slide-prev.slide
       #slide-next.slide
+    #add-channel-button
   .content
+
+script(id="add_new_channel", type="text/html")
+  i(class="icon-plus-sign spacing-right")
+  Add new channel 
+
+script(id="add_new_channel_form", type="text/html")
+  input#channelname(type="text", placeholder="#channelname")
 
 script(id="load_image", type="text/html")
   img(id="loading_image", src="/assets/images/loading.gif")


### PR DESCRIPTION
Fixes issue #123 and adds a button under the channel list for easily inputing a
channel name and pressing enter. This should make it more easy for new users to
IRC, joining channels. Someone with a better feel for UI may want to look at
how to make this prettier and even simpler.

It looks like this:

![screen shot 2014-02-17 at 15 30 21](https://f.cloud.github.com/assets/116978/2186120/03565ff2-97e1-11e3-8e54-625cfe45d75e.png)
![screen shot 2014-02-17 at 15 29 59](https://f.cloud.github.com/assets/116978/2186121/036f7410-97e1-11e3-9532-e2bc93e8eb82.png)

One may perhaps look into how HipChat does it, which looks like this:

![screen shot 2014-02-17 at 15 38 18](https://f.cloud.github.com/assets/116978/2186134/2a048e12-97e1-11e3-8d54-5b7b672ee717.png)
