### PR TITLE
Load fonts over SSL; otherwise they won't load when Subway is on SSL

### DIFF
--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -6,7 +6,7 @@ html
     title Subway IRC client
     meta(name='description', content='The Subway IRC client')
     meta(name='viewport', content='width=device-width, initial-scale=1')
-    link(href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700,800" rel="stylesheet" type="text/css")
+    link(href="//fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700,800" rel="stylesheet" type="text/css")
     each file in css_output
       link(rel="stylesheet", href="#{file}")
 


### PR DESCRIPTION
Chrome: [blocked] The page at 'https://foo/' was loaded over HTTPS, but ran insecure content from 'http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,300,600,700,800': this content should also be loaded over HTTPS.
