### PR TITLE
Update bower to fix initialization problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jugglingdb": "0.2.x",
     "jugglingdb-sqlite3": "0.0.x",
     "node-uuid": "1.4.x",
-    "bower": "1.2.x",
+    "bower": "1.3.x",
     "suspend": "0.4.x",
     "glob": "3.2.8",
     "gaze": "0.4.x",


### PR DESCRIPTION
Fixes bower error:
lib/node_modules/bower/node_modules/q/q.js:126
                    throw e;
