### PR TITLE
Fix launching instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Installation
 
 3. Launch the web server
 
-        $ ./subway
+        $ ./subway.js
 
 4. Point your browser at `http://localhost:3000/`
 


### PR DESCRIPTION
When installing subway I realized ./subway did not execute after npm installing. Doing ./subway.js works. Perhaps this was assuming the system auto identified JS files?
